### PR TITLE
Disable some vulkan device features when current platform is android

### DIFF
--- a/Samples/SampleBase/src/SampleApp.cpp
+++ b/Samples/SampleBase/src/SampleApp.cpp
@@ -198,6 +198,12 @@ void SampleApp::InitializeDiligentEngine(
             LoadGraphicsEngineVk(GetEngineFactoryVk);
 #endif
             EngineVkAttribs EngVkAttribs;
+#if PLATFORM_ANDROID
+            EngVkAttribs.EnabledFeatures.samplerAnisotropy = false;
+            EngVkAttribs.EnabledFeatures.geometryShader = false;
+            EngVkAttribs.EnabledFeatures.tessellationShader = false;
+#endif
+
 #ifdef _DEBUG
             EngVkAttribs.EnableValidation = true;
 #endif

--- a/Samples/SampleBase/src/SampleBase.cpp
+++ b/Samples/SampleBase/src/SampleBase.cpp
@@ -64,7 +64,13 @@ void SampleBase::GetEngineInitializationAttribs(DeviceType DevType, EngineCreati
         case DeviceType::Vulkan:
         {
             EngineVkAttribs &EngVkAttribs = static_cast<EngineVkAttribs&>(Attribs);
+#if PLATFORM_ANDROID
+            EngVkAttribs.EnabledFeatures.samplerAnisotropy = false;
+            EngVkAttribs.EnabledFeatures.geometryShader = false;
+            EngVkAttribs.EnabledFeatures.tessellationShader = false;
+#else
             EngVkAttribs.EnabledFeatures.multiViewport = true;
+#endif
         }
         break;
 #endif


### PR DESCRIPTION
Disable some features on EngineVkAttribs when current platform is android. 

These features are not supported on vulkan 1.0.

Vulkan 1.1 will be support these features. 