### PR TITLE
fix crash due to event race

### DIFF
--- a/SampleBase/src/Android/SampleAppAndroid.cpp
+++ b/SampleBase/src/Android/SampleAppAndroid.cpp
@@ -140,14 +140,14 @@ public:
                                                         m_SwapChainInitDesc, AndroidWindow,
                                                         &m_pSwapChain);
                 m_TheSample->ResetSwapChain(m_pSwapChain);
-                paused = m_pSwapChain;
-                return paused ? EGL_SUCCESS : EGL_NOT_INITIALIZED;
+                paused = m_pSwapChain ? false : true;
+                return (!paused) ? EGL_SUCCESS : EGL_NOT_INITIALIZED;
             }
 #endif
 
             case RENDER_DEVICE_TYPE_GLES: {
                 auto ret = m_RenderDeviceGLES->Resume(window);
-                paused = ret == EGL_SUCCESS ? true : false;
+                paused = ret == EGL_SUCCESS ? false : true;
                 return ret;
             }
 


### PR DESCRIPTION
an event race can occur whereby the application gets notified of the Resume event but its DrawFrame event gets called at the same time

in opengl this can crash due to the surface being raced to be set in Resume, and read in DrawFrame

this fixes onDraw so it will only draw is paused is false

paused becomes true when Initialize is called and completes

paused becomes true when Resume is called and completes with success

paused becomes false when TermDisplay is called regardless of if an error occurs