### PR TITLE
specify texture format as TEX_FORMAT_R16_SINT

### DIFF
--- a/Tutorials/Tutorial08_Tessellation/src/Tutorial08_Tessellation.cpp
+++ b/Tutorials/Tutorial08_Tessellation/src/Tutorial08_Tessellation.cpp
@@ -250,6 +250,7 @@ void Tutorial08_Tessellation::LoadTextures()
     {
         // Load texture
         TextureLoadInfo loadInfo;
+        loadInfo.Format = TEX_FORMAT_R16_SINT;
         loadInfo.IsSRGB = false;
         loadInfo.Name   = "Terrain height map";
         RefCntAutoPtr<ITexture> HeightMap;


### PR DESCRIPTION
specify texture format as TEX_FORMAT_R16_SINT

the texture may be loaded as TEX_FORMAT_R16_UNORM which is not supported everywhere, causing a crash on unsupported devices