### PR TITLE
Set render targets before clearing and drawing

### DIFF
--- a/Tutorials/Tutorial01_HelloTriangle/readme.md
+++ b/Tutorials/Tutorial01_HelloTriangle/readme.md
@@ -181,6 +181,7 @@ Before rendering anything on the screen we want to clear it:
 const float ClearColor[] = {  0.350f,  0.350f,  0.350f, 1.0f }; 
 auto* pRTV = m_pSwapChain->GetCurrentBackBufferRTV();
 auto* pDSV = m_pSwapChain->GetDepthBufferDSV();
+m_pImmediateContext->SetRenderTargets(1, &pRTV, pDSV, RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
 m_pImmediateContext->ClearRenderTarget(pRTV, ClearColor, RESOURCE_STATE_TRANSITION_MODE_TRANSITION);
 m_pImmediateContext->ClearDepthStencil(pDSV, CLEAR_DEPTH_FLAG, 1.f, 0,
                                        RESOURCE_STATE_TRANSITION_MODE_TRANSITION);


### PR DESCRIPTION
In tutorial 1 i added SetRenderTargets before clearing targets.
Without this line of code i get the error:
`E/Diligent Engine: Diligent Engine: ERROR: Debug assertion failed in PrepareForDraw(), file DeviceContextVkImpl.cpp, line 699:
    No render pass is active while executing draw command`